### PR TITLE
Potential security issue in src/login/login.cpp: Unchecked return from initialization function

### DIFF
--- a/src/login/login.cpp
+++ b/src/login/login.cpp
@@ -691,7 +691,7 @@ bool login_config_read(const char* cfgName, bool normal) {
 					int i;
 					for (i = 0; i < 32; i += 2) {
 						char buf[3];
-						unsigned int byte;
+						unsigned int byte = 0;
 
 						memcpy(buf, &md5[i], 2);
 						buf[2] = 0;


### PR DESCRIPTION
<span> What is a&nbsp;</span><span><b>Conditionally Uninitialized Variable? </b></span><span> The return value of a function that is potentially used to initialize a local variable is not checked. Therefore, reading the local variable may result in undefined behavior.</span>
---

1 instance of this defect were found in the following locations:
---
**Instance 1**
File : `src/login/login.cpp` 
Function: `sscanf` 
https://github.com/siva-msft/Pandas/blob/8cc6896117eb1bb35899a5778b0e41f55516bfa7/src/login/login.cpp#L699
Code extract:

```cpp
						memcpy(buf, &md5[i], 2);
						buf[2] = 0;

						sscanf(buf, "%2x", &byte); <------ HERE
						nnode->hash[i / 2] = (uint8)(byte & 0xFF);
					}
```

