### PR TITLE
Potential security issue in src/map/intif.cpp: Unchecked return from initialization function

### DIFF
--- a/src/map/intif.cpp
+++ b/src/map/intif.cpp
@@ -2735,7 +2735,7 @@ int intif_Auction_register(struct auction_data *auction)
 static void intif_parse_Auction_register(int fd)
 {
 	struct map_session_data *sd;
-	struct auction_data auction;
+	struct auction_data auction = {};
 
 	if( RFIFOW(fd,2) - 4 != sizeof(struct auction_data) )
 	{


### PR DESCRIPTION
<span> What is a&nbsp;</span><span><b>Conditionally Uninitialized Variable? </b></span><span> The return value of a function that is potentially used to initialize a local variable is not checked. Therefore, reading the local variable may result in undefined behavior.</span>
---

1 instance of this defect were found in the following locations:
---
**Instance 1**
File : `src/map/intif.cpp` 
Function: `pc_additem` 
https://github.com/siva-msft/Pandas/blob/8cc6896117eb1bb35899a5778b0e41f55516bfa7/src/map/intif.cpp#L2761
Code extract:

```cpp
		int zeny = auction.hours*battle_config.auction_feeperhour;

		clif_Auction_message(sd->fd, 4);
		pc_additem(sd, &auction.item, auction.item.amount, LOG_TYPE_AUCTION); <------ HERE

		pc_getzeny(sd, zeny, LOG_TYPE_AUCTION, NULL);
```

