### PR TITLE
Potential security issue in src/map/mapreg.cpp: Unchecked return from initialization function

### DIFF
--- a/src/map/mapreg.cpp
+++ b/src/map/mapreg.cpp
@@ -188,9 +188,9 @@ static void script_load_mapreg(void)
 	                                */
 	SqlStmt* stmt = SqlStmt_Malloc(mmysql_handle);
 	char varname[32+1];
-	uint32 index;
+	uint32 index = 0;
 	char value[255+1];
-	uint32 length;
+	uint32 length = 0;
 
 	if ( SQL_ERROR == SqlStmt_Prepare(stmt, "SELECT `varname`, `index`, `value` FROM `%s`", mapreg_table)
 	  || SQL_ERROR == SqlStmt_Execute(stmt)


### PR DESCRIPTION
<span> What is a&nbsp;</span><span><b>Conditionally Uninitialized Variable? </b></span><span> The return value of a function that is potentially used to initialize a local variable is not checked. Therefore, reading the local variable may result in undefined behavior.</span>
---

2 instances of this defect were found in the following locations:
---
**Instance 1**
File : `src/map/mapreg.cpp` 
Function: `SqlStmt_BindColumn` 
https://github.com/siva-msft/Pandas/blob/8cc6896117eb1bb35899a5778b0e41f55516bfa7/src/map/mapreg.cpp#L205
Code extract:

```cpp

	skip_insert = true;

	SqlStmt_BindColumn(stmt, 0, SQLDT_STRING, &varname[0], sizeof(varname), &length, NULL); <------ HERE
	SqlStmt_BindColumn(stmt, 1, SQLDT_UINT32, &index, 0, NULL, NULL);
	SqlStmt_BindColumn(stmt, 2, SQLDT_STRING, &value[0], sizeof(value), NULL, NULL);
```

---
**Instance 2**
File : `src/map/mapreg.cpp` 
Function: `SqlStmt_BindColumn` 
https://github.com/siva-msft/Pandas/blob/8cc6896117eb1bb35899a5778b0e41f55516bfa7/src/map/mapreg.cpp#L206
Code extract:

```cpp
	skip_insert = true;

	SqlStmt_BindColumn(stmt, 0, SQLDT_STRING, &varname[0], sizeof(varname), &length, NULL);
	SqlStmt_BindColumn(stmt, 1, SQLDT_UINT32, &index, 0, NULL, NULL); <------ HERE
	SqlStmt_BindColumn(stmt, 2, SQLDT_STRING, &value[0], sizeof(value), NULL, NULL);

```

