### PR TITLE
Potential security issue in src/map/mob.cpp: Unchecked return from initialization function

### DIFF
--- a/src/map/mob.cpp
+++ b/src/map/mob.cpp
@@ -3400,7 +3400,7 @@ int mob_warpslave_sub(struct block_list *bl,va_list ap)
 {
 	struct mob_data *md=(struct mob_data *)bl;
 	struct block_list *master;
-	short x,y,range=0;
+	short x,y = 0,range=0;
 	master = va_arg(ap, struct block_list*);
 	range = va_arg(ap, int);
 
@@ -4423,8 +4423,8 @@ static int mob_read_sqldb(void)
 			lines++;
 			for(i = 0, p = line; i < 31+2*MAX_MVP_DROP+2*MAX_MOB_DROP; i++)
 			{
-				char* data;
-				size_t len;
+				char* data = nullptr;
+				size_t len = 0;
 				Sql_GetData(mmysql_handle, i, &data, &len);
 
 				strcpy(p, data);


### PR DESCRIPTION
<span> What is a&nbsp;</span><span><b>Conditionally Uninitialized Variable? </b></span><span> The return value of a function that is potentially used to initialize a local variable is not checked. Therefore, reading the local variable may result in undefined behavior.</span>
---

2 instances of this defect were found in the following locations:
---
**Instance 1**
File : `src/map/mob.cpp` 
Function: `map_search_freecell` 
https://github.com/siva-msft/Pandas/blob/8cc6896117eb1bb35899a5778b0e41f55516bfa7/src/map/mob.cpp#L3410
Code extract:

```cpp
	if(md->master_id!=master->id)
		return 0;

	map_search_freecell(master, 0, &x, &y, range, range, 0); <------ HERE
	unit_warp(&md->bl, master->m, x, y,CLR_TELEPORT);
	return 1;
```

---
**Instance 2**
File : `src/map/mob.cpp` 
Function: `Sql_GetData` 
https://github.com/siva-msft/Pandas/blob/8cc6896117eb1bb35899a5778b0e41f55516bfa7/src/map/mob.cpp#L4428
Code extract:

```cpp
			{
				char* data;
				size_t len;
				Sql_GetData(mmysql_handle, i, &data, &len); <------ HERE

				strcpy(p, data);
```

