### PR TITLE
Potential security issue in src/map/pc.cpp: Unchecked return from initialization function

### DIFF
--- a/src/map/pc.cpp
+++ b/src/map/pc.cpp
@@ -12220,7 +12220,7 @@ static bool pc_readdb_job_basehpsp(char* fields[], int columns, int current)
 */
 static bool pc_readdb_job_param(char* fields[], int columns, int current)
 {
-	int64 class_tmp;
+	int64 class_tmp = 0;
 	int idx, class_;
 	uint16 str, agi, vit, int_, dex, luk;
 


### PR DESCRIPTION
<span> What is a&nbsp;</span><span><b>Conditionally Uninitialized Variable? </b></span><span> The return value of a function that is potentially used to initialize a local variable is not checked. Therefore, reading the local variable may result in undefined behavior.</span>
---

1 instance of this defect were found in the following locations:
---
**Instance 1**
File : `src/map/pc.cpp` 
Function: `script_get_constant` 
https://github.com/siva-msft/Pandas/blob/8cc6896117eb1bb35899a5778b0e41f55516bfa7/src/map/pc.cpp#L12227
Code extract:

```cpp
	int idx, class_;
	uint16 str, agi, vit, int_, dex, luk;

	script_get_constant(trim(fields[0]),&class_tmp); <------ HERE
	class_ = static_cast<int>(class_tmp);

```

