### PR TITLE
Potential security issue in src/map/skill.cpp: Unchecked return from initialization function

### DIFF
--- a/src/map/skill.cpp
+++ b/src/map/skill.cpp
@@ -4251,7 +4251,7 @@ static TIMER_FUNC(skill_timerskill){
 					break;
 				case RG_INTIMIDATE:
 					if (unit_warp(src,-1,-1,-1,CLR_TELEPORT) == 0) {
-						short x,y;
+						short x,y = 0;
 						map_search_freecell(src, 0, &x, &y, 1, 1, 0);
 						if (target != src && !status_isdead(target))
 							unit_warp(target, -1, x, y, CLR_TELEPORT);
@@ -5585,7 +5585,7 @@ int skill_castend_damage_id (struct block_list* src, struct block_list *bl, uint
 	case NJ_KIRIKAGE:
 		if( !map_flag_gvg2(src->m) && !map_getmapflag(src->m, MF_BATTLEGROUND) )
 		{	//You don't move on GVG grounds.
-			short x, y;
+			short x, y = 0;
 			map_search_freecell(bl, 0, &x, &y, 1, 1, 0);
 			if (unit_movepos(src, x, y, 0, 0)) {
 				clif_blown(src);


### PR DESCRIPTION
<span> What is a&nbsp;</span><span><b>Conditionally Uninitialized Variable? </b></span><span> The return value of a function that is potentially used to initialize a local variable is not checked. Therefore, reading the local variable may result in undefined behavior.</span>
---

4 instances of this defect were found in the following locations:
---
**Instance 1**
File : `src/map/skill.cpp` 
Function: `map_search_freecell` 
https://github.com/siva-msft/Pandas/blob/8cc6896117eb1bb35899a5778b0e41f55516bfa7/src/map/skill.cpp#L4255
Code extract:

```cpp
				case RG_INTIMIDATE:
					if (unit_warp(src,-1,-1,-1,CLR_TELEPORT) == 0) {
						short x,y;
						map_search_freecell(src, 0, &x, &y, 1, 1, 0); <------ HERE
						if (target != src && !status_isdead(target))
							unit_warp(target, -1, x, y, CLR_TELEPORT);
```

---
**Instance 2**
File : `src/map/skill.cpp` 
Function: `map_search_freecell` 
https://github.com/siva-msft/Pandas/blob/8cc6896117eb1bb35899a5778b0e41f55516bfa7/src/map/skill.cpp#L5589
Code extract:

```cpp
		if( !map_flag_gvg2(src->m) && !map_getmapflag(src->m, MF_BATTLEGROUND) )
		{	//You don't move on GVG grounds.
			short x, y;
			map_search_freecell(bl, 0, &x, &y, 1, 1, 0); <------ HERE
			if (unit_movepos(src, x, y, 0, 0)) {
				clif_blown(src);
```

---
**Instance 3**
File : `src/map/skill.cpp` 
Function: `strtol` 
https://github.com/siva-msft/Pandas/blob/8cc6896117eb1bb35899a5778b0e41f55516bfa7/src/map/skill.cpp#L22722
Code extract:

```cpp
	skill->damage = {};
	trim(split[1]);
	if (ISDIGIT(split[1][0])) {
		value = strtol(split[1], &result, 10); <------ HERE

		if (*result) {
```

---
**Instance 4**
File : `src/map/skill.cpp` 
Function: `strtol` 
https://github.com/siva-msft/Pandas/blob/8cc6896117eb1bb35899a5778b0e41f55516bfa7/src/map/skill.cpp#L22739
Code extract:

```cpp
	}
	skill->damage.caster |= caster;

	value = strtol(split[2], &result, 10); <------ HERE

	if (*result) {
```

